### PR TITLE
Reuse an (existing) Bunny::Session in/with Cony

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Cony.configure do |config|
 end
 ```
 
+### Using an existing Bunny connection
+
+You can share your already established `Bunny::Session` with Cony.
+
+```ruby
+Cony::AMQPConnection.instance.connection = your_connection
+```
+
+Cony will only accept the given connection if it's current connection is closed or if there is no current
+connection. There will be **no** error if Cony uses it's current connection in favor of the provided
+connection!
 
 ## Getting Started
 

--- a/lib/cony.rb
+++ b/lib/cony.rb
@@ -9,6 +9,21 @@ require 'active_support/configurable'
 
 require 'cony/active_record'
 
+##
+# To configure Cony:
+# <code>
+# Cony.configure do |config|
+#   config.amqp = {
+#     host: 'localhost',
+#     exchange: 'organization.application',
+#     ssl: true,
+#     user: 'username',
+#     pass: 'secret',
+#   }
+#   config.test_mode = Rails.env.test?
+#   # config.durable = false
+# end
+# </code>
 module Cony
   include ActiveSupport::Configurable
 

--- a/lib/cony/active_record.rb
+++ b/lib/cony/active_record.rb
@@ -4,6 +4,15 @@ require 'cony'
 require 'cony/amqp_connection'
 
 module Cony
+  ##
+  # Usage:
+  # <code>
+  # class FooBar < ActiveRecord::Base
+  #   include Cony::ActiveRecord
+  #   # your things here
+  # end
+  # </code>
+  #
   module ActiveRecord
     extend ActiveSupport::Concern
 

--- a/lib/cony/active_record.rb
+++ b/lib/cony/active_record.rb
@@ -1,7 +1,7 @@
 require 'active_support/core_ext/string/inflections'
 
 require 'cony'
-require 'cony/amqp_connection_handler'
+require 'cony/amqp_connection'
 
 module Cony
   module ActiveRecord
@@ -29,14 +29,11 @@ module Cony
 
     def cony_publish
       return if Cony.config.test_mode
-      cony_amqp_connection.publish(cony_notify_hash, cony_notify_routing_key)
+
+      Cony::AMQPConnection.publish(cony_notify_hash, cony_notify_routing_key)
     end
 
     private
-
-    def cony_amqp_connection
-      @cony_amqp_connection ||= Cony::AMQPConnectionHandler.new(Cony.config.amqp)
-    end
 
     def cony_mapped_changes
       changes.map do |name, change|

--- a/lib/cony/active_record.rb
+++ b/lib/cony/active_record.rb
@@ -5,7 +5,6 @@ require 'cony/amqp_connection_handler'
 
 module Cony
   module ActiveRecord
-
     extend ActiveSupport::Concern
 
     included do
@@ -34,6 +33,7 @@ module Cony
     end
 
     private
+
     def cony_amqp_connection
       @cony_amqp_connection ||= Cony::AMQPConnectionHandler.new(Cony.config.amqp)
     end

--- a/lib/cony/amqp_connection.rb
+++ b/lib/cony/amqp_connection.rb
@@ -3,13 +3,20 @@ require 'json'
 require 'singleton'
 
 module Cony
+  ##
+  # The only place in cony that deals with AMQP connection and it's lifecycle
   class AMQPConnection
     include Singleton
 
+    ##
+    # Shorthand for +Cony::AMQPConnection.instance.publish+
     def self.publish(message, routing_key)
       instance.publish(message, routing_key)
     end
 
+    ##
+    # :category: Internal
+    # Sends the status change message to the configured AMQP destination
     def publish(message, routing_key)
       channel = connection.create_channel
       exchange = channel.topic(Cony.config.amqp[:exchange], durable: Cony.config.durable)
@@ -24,10 +31,14 @@ module Cony
       Rails.logger.error("#{error.class}: #{error}") if defined? Rails
     end
 
+    ##
+    # Sets a custom connection if no valid_connection? is already provided
     def connection=(connection)
       @connection = connection if invalid_connection?
     end
 
+    ##
+    # Returns the existing connection or creates a new connection
     def connection
       return @connection if valid_connection?
 
@@ -36,10 +47,14 @@ module Cony
       @connection.start
     end
 
+    ##
+    # +true+ if there's currently no connection or the connection has been closed
     def invalid_connection?
       @connection.nil? || @connection.closed?
     end
 
+    ##
+    # +false+ if invalid_connection? is +true+
     def valid_connection?
       !invalid_connection?
     end

--- a/lib/cony/amqp_connection.rb
+++ b/lib/cony/amqp_connection.rb
@@ -24,18 +24,30 @@ module Cony
       Rails.logger.error("#{error.class}: #{error}") if defined? Rails
     end
 
-    private
+    def connection=(connection)
+      @connection = connection if invalid_connection?
+    end
 
     def connection
-      return @connection unless @connection.nil? || @connection.closed?
+      return @connection if valid_connection?
 
       @connection = Bunny.new Cony.config.amqp
       ObjectSpace.define_finalizer(self, proc { cleanup })
       @connection.start
     end
 
+    def invalid_connection?
+      @connection.nil? || @connection.closed?
+    end
+
+    def valid_connection?
+      !invalid_connection?
+    end
+
+    private
+
     def cleanup
-      @connection.close unless @connection.closed?
+      @connection.close if valid_connection?
     end
   end
 end

--- a/lib/cony/amqp_connection_handler.rb
+++ b/lib/cony/amqp_connection_handler.rb
@@ -9,20 +9,31 @@ module Cony
     end
 
     def publish(message, routing_key)
-      Bunny.run(@config) do |connection|
-        channel = connection.create_channel
-        exchange = channel.topic(@config[:exchange], durable: Cony.config.durable)
-        exchange.publish(message.to_json,
-                         key: routing_key,
-                         mandatory: false,
-                         immediate: false,
-                         persistent: Cony.config.durable,
-                         content_type: 'application/json')
-      end
+      channel = connection.create_channel
+      exchange = channel.topic(@config[:exchange], durable: Cony.config.durable)
+      exchange.publish(message.to_json,
+                       key: routing_key,
+                       mandatory: false,
+                       immediate: false,
+                       persistent: Cony.config.durable,
+                       content_type: 'application/json')
     rescue => error
-      Airbrake.notify(error) if defined?(Airbrake)
-      Rails.logger.error("#{error.class}: #{error}") if defined?(Rails)
+      Airbrake.notify(error) if defined? Airbrake
+      Rails.logger.error("#{error.class}: #{error}") if defined? Rails
     end
 
+    private
+
+    def connection
+      return @connection unless @connection.nil? || @connection.closed?
+
+      @connection = Bunny.new @config
+      ObjectSpace.define_finalizer(self, proc { cleanup })
+      @connection.start
+    end
+
+    def cleanup
+      @connection.close unless @connection.closed?
+    end
   end
 end

--- a/lib/cony/amqp_connection_handler.rb
+++ b/lib/cony/amqp_connection_handler.rb
@@ -3,9 +3,11 @@ require 'json'
 
 module Cony
   class AMQPConnectionHandler
-
-    def initialize(config)
+    def initialize(config, connection = nil)
       @config = config
+      @connection = connection
+
+      @connection.start unless @connection.nil? || @connection.open?
     end
 
     def publish(message, routing_key)

--- a/spec/cony/active_record_spec.rb
+++ b/spec/cony/active_record_spec.rb
@@ -4,7 +4,7 @@ require 'cony/active_record'
 
 describe Cony::ActiveRecord do
 
-  let(:amqp_connection) { double('Cony::AMQPConnectionHandler') }
+  let(:amqp_connection) { double('Cony::AMQPConnection') }
   let(:id) { 1337 }
   let(:active_record_changes) { {name: ['old', 'new']} }
   let(:active_record_attributes) { {name: 'value'} }
@@ -36,7 +36,7 @@ describe Cony::ActiveRecord do
   end
 
   before do
-    allow(Cony::AMQPConnectionHandler).to receive(:new).and_return(amqp_connection)
+    allow(Cony::AMQPConnection).to receive(:instance).and_return(amqp_connection)
   end
 
   subject { model.new }
@@ -74,7 +74,7 @@ describe Cony::ActiveRecord do
       allow(Cony.config).to receive(:test_mode).and_return(true)
     end
     it 'does not send the message' do
-      expect(Cony::AMQPConnectionHandler).to_not receive(:new)
+      expect(Cony::AMQPConnection).to_not receive(:instance)
       subject.cony_save_create_notify_data
       subject.cony_publish
     end


### PR DESCRIPTION
* Makes Cony to only create one Bunny::Session and re-use it
* Allows Cony to use an externally initialized Bunny::Session