### PR TITLE
Sane way of providing an existing connection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cony (2.0.1)
+    cony (2.1.0)
       activesupport (>= 3)
       bunny (~> 2.3)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ To configure the AMQP-Settings, use an initializer (e.g.
 
 ```ruby
 Cony.configure do |config|
+  config.test_mode = Rails.env.test?
+  # config.durable = false
   config.amqp = {
     host: 'localhost',
     exchange: 'organization.application',
@@ -25,22 +27,10 @@ Cony.configure do |config|
     user: 'username',
     pass: 'secret',
   }
-  config.test_mode = Rails.env.test?
-  # config.durable = false
+  # or:
+  # config.amqp_connection = my_existing_bunny_session
 end
 ```
-
-### Using an existing Bunny connection
-
-You can share your already established `Bunny::Session` with Cony.
-
-```ruby
-Cony::AMQPConnection.instance.connection = your_connection
-```
-
-Cony will only accept the given connection if it's current connection is closed or if there is no current
-connection. There will be an error if Cony already has a connection!
-This restriction is imposed because else Cony might leak connections.
 
 ## Getting Started
 

--- a/lib/cony.rb
+++ b/lib/cony.rb
@@ -13,6 +13,8 @@ require 'cony/active_record'
 # To configure Cony:
 # <code>
 # Cony.configure do |config|
+#   config.test_mode = Rails.env.test?
+#   # config.durable = false
 #   config.amqp = {
 #     host: 'localhost',
 #     exchange: 'organization.application',
@@ -20,8 +22,8 @@ require 'cony/active_record'
 #     user: 'username',
 #     pass: 'secret',
 #   }
-#   config.test_mode = Rails.env.test?
-#   # config.durable = false
+#   # or:
+#   # config.amqp_connection = my_existing_bunny_session
 # end
 # </code>
 module Cony

--- a/lib/cony/amqp_connection.rb
+++ b/lib/cony/amqp_connection.rb
@@ -32,6 +32,7 @@ module Cony
 
     ##
     # Sets a custom connection if no valid_connection? is already provided
+    # :deprecated: Use the Cony Initializer
     def connection=(connection)
       fail Cony::ValidConnectionAlreadyDefined, 'A connection has already been set.' if valid_connection_present?
       @connection = connection
@@ -42,7 +43,9 @@ module Cony
     def connection
       return @connection if valid_connection_present?
 
-      @connection = Bunny.new Cony.config.amqp
+      return @connection = Cony.config.amqp_connection unless Cony.config.amqp_connection.nil?
+
+      @connection = Bunny.new(Cony.config.amqp)
       ObjectSpace.define_finalizer(self, proc { cleanup })
       @connection.start
     end

--- a/spec/cony/amqp_connection_spec.rb
+++ b/spec/cony/amqp_connection_spec.rb
@@ -121,6 +121,16 @@ describe Cony::AMQPConnection do
         expect { subject.instance.connection = existing_connection }.
           to raise_error(Cony::ValidConnectionAlreadyDefined)
       end
+
+      describe 'no amqp config hash given' do
+        let(:config) do
+          double('Cony Config', amqp: nil, durable: false, amqp_connection: existing_connection)
+        end
+
+        it 'still uses the connection from the config' do
+          expect(subject.instance.connection).to be(existing_connection)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Namely through the initializer instead of that workaround I previously installed.